### PR TITLE
Filter by protocol

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,16 @@
 'use strict';
 
-var jsRegex = /^javascript:.*/im;
-var ctrlCharactersRegex = /[^\x20-\x7E]/gmi;
+var notVisibleAsciiRegex = /[^\x20-\x7E]/gmi;
+var safeRegex = /^https?:\/\/[^\/\.]+/i;
 
 function sanitizeUrl(url) {
-  var sanitizedUrl = url.replace(ctrlCharactersRegex, '');
+  var sanitizedUrl = url.replace(notVisibleAsciiRegex, '');
 
-  return sanitizedUrl.replace(jsRegex, 'about:blank');
+  if (safeRegex.test(sanitizedUrl)) {
+    return url;
+  } else {
+    return 'about:blank';
+  }
 }
 
 module.exports = {

--- a/test/test.js
+++ b/test/test.js
@@ -4,15 +4,44 @@ var expect = require('chai').expect;
 var sanitizeUrl = require('../').sanitizeUrl;
 
 describe('sanitizeUrl', function () {
-  it('replaces javascript urls with about:blank', function () {
+  it('allows normal URLs through', function () {
+    expect(sanitizeUrl('http://example.com')).to.equal('http://example.com');
+    expect(sanitizeUrl('https://example.com')).to.equal('https://example.com');
+    expect(sanitizeUrl('https://example.com/with/path')).to.equal('https://example.com/with/path');
+    expect(sanitizeUrl('hTTPs://example.com')).to.equal('hTTPs://example.com');
+    expect(sanitizeUrl('HTTPS://EXAMPLE.COM')).to.equal('HTTPS://EXAMPLE.COM');
+  });
+
+  it('replaces empty URLs with about:blank', function () {
+    expect(sanitizeUrl('')).to.equal('about:blank');
+    expect(sanitizeUrl(' ')).to.equal('about:blank');
+  });
+
+  it('replaces protocol-only URLs with about:blank', function () {
+    expect(sanitizeUrl('http://')).to.equal('about:blank');
+    expect(sanitizeUrl('https://')).to.equal('about:blank');
+  });
+
+  it('replaces TLD-only URLs with about:blank', function () {
+    expect(sanitizeUrl('http://.com')).to.equal('about:blank');
+  });
+
+  it('replaces URLs with preceding whitespace with about:blank', function () {
+    expect(sanitizeUrl(' https://example.com')).to.equal('about:blank');
+    expect(sanitizeUrl('  https://example.com')).to.equal('about:blank');
+  });
+
+  it('replaces URLs with non-HTTP protocols with about:blank', function () {
+    expect(sanitizeUrl('file://example.com')).to.equal('about:blank');
+    expect(sanitizeUrl('file:///path/to/file')).to.equal('about:blank');
+    expect(sanitizeUrl('ftp://example.com')).to.equal('about:blank');
+    expect(sanitizeUrl('httpnope://example.com')).to.equal('about:blank');
     expect(sanitizeUrl('javascript:alert(document.domain)')).to.equal('about:blank');
-  });
-
-  it('disregards capitalization for JavaScript urls', function () {
     expect(sanitizeUrl('jAvasCrIPT:alert(document.domain)')).to.equal('about:blank');
+    expect(sanitizeUrl('javascript://example.com')).to.equal('about:blank');
   });
 
-  it('ignores ctrl characters in javascript urls', function () {
+  it('ignores control characters in JavaScript urls', function () {
     expect(sanitizeUrl(decodeURIComponent('JaVaScRiP%0at:alert(document.domain)'))).to.equal('about:blank');
   });
 });


### PR DESCRIPTION
Feel free to ignore this suggestion.

Instead of blacklisting `javascript:`, this whitelists `http:` and `https:` protocols.