### PR TITLE
Allow relative URLs to pass through the sanitizer

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,13 +3,14 @@
 var invalidPrototcolRegex = /^(%20|\s)*(javascript|data)/im;
 var ctrlCharactersRegex = /[^\x20-\x7E]/gmi;
 var urlSchemeRegex = /^([^:]+):/gm;
+var relativeFirstCharacters = [".", "/"]
 
 function sanitizeUrl(url) {
   var urlScheme;
   var sanitizedUrl = url.replace(ctrlCharactersRegex, '');
   var urlSchemeParseResults = sanitizedUrl.match(urlSchemeRegex) || [];
 
-  if (!urlSchemeParseResults.length && url[0] !== "/") {
+  if (!urlSchemeParseResults.length && relativeFirstCharacters.indexOf(url[0]) === -1) {
     return 'about:blank';
   }
 

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ var urlSchemeRegex = /^([^:]+):/gm;
 function sanitizeUrl(url) {
   var urlScheme;
   var sanitizedUrl = url.replace(ctrlCharactersRegex, '');
-  var urlSchemeParseResults = sanitizedUrl.match(urlSchemeRegex);
+  var urlSchemeParseResults = sanitizedUrl.match(urlSchemeRegex) || [];
 
-  if (!urlSchemeParseResults) {
+  if (!urlSchemeParseResults.length && url[0] !== "/") {
     return 'about:blank';
   }
 

--- a/index.js
+++ b/index.js
@@ -5,12 +5,21 @@ var ctrlCharactersRegex = /[^\x20-\x7E]/gmi;
 var urlSchemeRegex = /^([^:]+):/gm;
 var relativeFirstCharacters = ['.', '/']
 
-function sanitizeUrl(url) {
-  var urlScheme;
-  var sanitizedUrl = url.replace(ctrlCharactersRegex, '');
-  var urlSchemeParseResults = sanitizedUrl.match(urlSchemeRegex) || [];
+function isRelativeUrl(url) {
+  return relativeFirstCharacters.indexOf(url[0]) > -1;
+}
 
-  if (!urlSchemeParseResults.length && relativeFirstCharacters.indexOf(url[0]) === -1) {
+function sanitizeUrl(url) {
+  var urlScheme, urlSchemeParseResults;
+  var sanitizedUrl = url.replace(ctrlCharactersRegex, '');
+  
+  if (isRelativeUrl(sanitizedUrl)) {
+    return sanitizedUrl;
+  }
+  
+  urlSchemeParseResults = sanitizedUrl.match(urlSchemeRegex);
+
+  if (!urlSchemeParseResults) {
     return 'about:blank';
   }
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var invalidPrototcolRegex = /^(%20|\s)*(javascript|data)/im;
 var ctrlCharactersRegex = /[^\x20-\x7E]/gmi;
 var urlSchemeRegex = /^([^:]+):/gm;
-var relativeFirstCharacters = [".", "/"]
+var relativeFirstCharacters = ['.', '/']
 
 function sanitizeUrl(url) {
   var urlScheme;

--- a/test/test.js
+++ b/test/test.js
@@ -64,6 +64,10 @@ describe('sanitizeUrl', function () {
     expect(sanitizeUrl('https://example.com:4567/path/to:something')).to.equal('https://example.com:4567/path/to:something');
   });
 
+  it('does not alter root-relative URLs', function () {
+    expect(sanitizeUrl('/path/to/my.json')).to.equal('/path/to/my.json');
+  });
+
   it('does not alter deep-link urls', function () {
     expect(sanitizeUrl('com.braintreepayments.demo://example')).to.equal('com.braintreepayments.demo://example');
   });

--- a/test/test.js
+++ b/test/test.js
@@ -64,12 +64,16 @@ describe('sanitizeUrl', function () {
     expect(sanitizeUrl('https://example.com:4567/path/to:something')).to.equal('https://example.com:4567/path/to:something');
   });
 
-  it('does not alter relative URLs', function () {
+  it('does not alter relative-path reference URLs', function () {
     expect(sanitizeUrl('./path/to/my.json')).to.equal('./path/to/my.json');
   });
 
-  it('does not alter root-relative URLs', function () {
+  it('does not alter absolute-path reference URLs', function () {
     expect(sanitizeUrl('/path/to/my.json')).to.equal('/path/to/my.json');
+  });
+
+  it('does not alter network-path relative URLs', function () {
+    expect(sanitizeUrl('//google.com/robots.txt')).to.equal('//google.com/robots.txt');
   });
 
   it('does not alter deep-link urls', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -64,6 +64,10 @@ describe('sanitizeUrl', function () {
     expect(sanitizeUrl('https://example.com:4567/path/to:something')).to.equal('https://example.com:4567/path/to:something');
   });
 
+  it('does not alter relative URLs', function () {
+    expect(sanitizeUrl('./path/to/my.json')).to.equal('./path/to/my.json');
+  });
+
   it('does not alter root-relative URLs', function () {
     expect(sanitizeUrl('/path/to/my.json')).to.equal('/path/to/my.json');
   });


### PR DESCRIPTION
Addresses an issue raised in https://github.com/swagger-api/swagger-ui/issues/4107.

Per [RFC 3986 Section 4.2](https://tools.ietf.org/html/rfc3986#section-4.2), relative reference URLs come in three flavors:
- relative-path (`./my.json`, `./myfolder/my.json`, `./`), which start with `.`
- absolute-path (`/my.json`, `/myfolder/my.json`, `/`), which start with `/`
- network-path (`//google.com/robots.txt`), which start with `//`

This PR adds support for all three flavors.

All existing tests continue to pass. I don't foresee any security issues w/r/t evil scheme URLs, since the same RFC clearly states that schemes can only be found at the beginning of URLs (`Each URI begins with a scheme name`). Since these special characters (`.` and `/`) indicate a relative URL, no URL parser should ever look for a scheme in such a URL.