### PR TITLE
Ignore protocol-less urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var ctrlCharactersRegex = /[^\x20-\x7E]/gmi;
 var urlSchemeRegex = /^([^:]+):/gm;
 var relativeFirstCharacters = ['.', '/'];
 
-function isUrlWithoutProtocol(url) {
+function isRelativeUrlWithoutProtocol(url) {
   return relativeFirstCharacters.indexOf(url[0]) > -1;
 }
 
@@ -18,7 +18,7 @@ function sanitizeUrl(url) {
 
   sanitizedUrl = url.replace(ctrlCharactersRegex, '').trim();
 
-  if (isUrlWithoutProtocol(sanitizedUrl)) {
+  if (isRelativeUrlWithoutProtocol(sanitizedUrl)) {
     return sanitizedUrl;
   }
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function sanitizeUrl(url) {
   urlSchemeParseResults = sanitizedUrl.match(urlSchemeRegex);
 
   if (!urlSchemeParseResults) {
-    return 'about:blank';
+    return sanitizedUrl;
   }
 
   urlScheme = urlSchemeParseResults[0];

--- a/test/test.js
+++ b/test/test.js
@@ -76,6 +76,10 @@ describe('sanitizeUrl', function () {
     expect(sanitizeUrl('//google.com/robots.txt')).to.equal('//google.com/robots.txt');
   });
 
+  it('does not alter protocol-less URLs', function () {
+    expect(sanitizeUrl('www.google.com')).to.equal('www.google.com');
+  });
+
   it('does not alter deep-link urls', function () {
     expect(sanitizeUrl('com.braintreepayments.demo://example')).to.equal('com.braintreepayments.demo://example');
   });

--- a/test/test.js
+++ b/test/test.js
@@ -96,6 +96,10 @@ describe('sanitizeUrl', function () {
     expect(sanitizeUrl(null)).to.equal('about:blank');
   });
 
+  it('replaces undefined values with about:blank', function () {
+    expect(sanitizeUrl()).to.equal('about:blank');
+  });
+
   it('removes whitespace from urls', function () {
     expect(sanitizeUrl('   http://example.com/path/to:something    ')).to.equal('http://example.com/path/to:something');
   });


### PR DESCRIPTION
# Items Addressed
- Resolves #18 (i.e., do not replace protocol-less urls with `about:blank`)
- Renamed helper function to be more explicit (`isUrlWithoutProtocol` -> `isRelativeUrlWithoutProtocol`)
- Added another test to demonstrate the expected behavior when passing `undefined`
