### PR TITLE
Allow URLs to include accented characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var invalidPrototcolRegex = /^(%20|\s)*(javascript|data)/im;
-var ctrlCharactersRegex = /[^\x20-\x7E]/gmi;
+var ctrlCharactersRegex = /[^\x20-\x7EÀ-ÖØ-öø-ÿ]/gmi;
 var urlSchemeRegex = /^([^:]+):/gm;
 var relativeFirstCharacters = ['.', '/'];
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var invalidPrototcolRegex = /^(%20|\s)*(javascript|data)/im;
-var ctrlCharactersRegex = /[^\x20-\x7EÀ-ÖØ-öø-ÿ]/gmi;
+var ctrlCharactersRegex = /[^\x20-\x7EÀ-ž]/gmi;
 var urlSchemeRegex = /^([^:]+):/gm;
 var relativeFirstCharacters = ['.', '/'];
 

--- a/test/test.js
+++ b/test/test.js
@@ -89,7 +89,7 @@ describe('sanitizeUrl', function () {
   });
 
   it('does not alter urls with accented characters', function () {
-    expect(sanitizeUrl('www.example.com/with-áccents')).to.equal('www.example.com/with-áccents');
+    expect(sanitizeUrl('www.example.com/with-áccêntš')).to.equal('www.example.com/with-áccêntš');
   });
 
   it('replaces blank urls with about:blank', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -88,6 +88,10 @@ describe('sanitizeUrl', function () {
     expect(sanitizeUrl('mailto:test@example.com?subject=hello+world')).to.equal('mailto:test@example.com?subject=hello+world');
   });
 
+  it('does not alter urls with accented characters', function () {
+    expect(sanitizeUrl('www.example.com/with-áccents')).to.equal('www.example.com/with-áccents');
+  });
+
   it('replaces blank urls with about:blank', function () {
     expect(sanitizeUrl('')).to.equal('about:blank');
   });


### PR DESCRIPTION
## Description
When sanitizing url with accents they get omitted from the return value. Ensure that urls with accents are allowed.

Fixes issue #20 

## Acceptance Criteria
- [ ] URLs with accents are allowed