### PR TITLE
Sanitize VBscript protocol

### DIFF
--- a/src/__tests__/test.ts
+++ b/src/__tests__/test.ts
@@ -80,6 +80,36 @@ describe("sanitizeUrl", () => {
     ).toBe("about:blank");
   });
 
+  it("replaces VBscript urls with about:blank", () => {
+    expect(sanitizeUrl("vbscript:msgbox('XSS')")).toBe("about:blank");
+  });
+
+  it("disregards capitalization for VBscript urls", () => {
+    expect(sanitizeUrl("vbScrIpT:mSGBOX('XSS')")).toBe("about:blank");
+  });
+
+  it("ignores ctrl characters in VBscript urls", () => {
+    expect(sanitizeUrl(decodeURIComponent("VbScRiP%0at:msgbox('XSS')"))).toBe(
+      "about:blank"
+    );
+  });
+
+  it("replaces VBscript urls with about:blank when VBscript url begins with %20", () => {
+    expect(sanitizeUrl("%20%20%20%20vbscript:msgbox('XSS')")).toBe(
+      "about:blank"
+    );
+  });
+
+  it("replaces VBScript urls with about:blank when VBscript url begins with s", () => {
+    expect(sanitizeUrl("    vbscript:msgbox('XSS')")).toBe("about:blank");
+  });
+
+  it("does not replace VBscript: if it is not in the scheme of the URL", () => {
+    expect(sanitizeUrl("http://example.com#whatisvbscript:foo")).toBe(
+      "http://example.com#whatisvbscript:foo"
+    );
+  });
+
   it("does not alter http URLs", () => {
     expect(sanitizeUrl("http://example.com/path/to:something")).toBe(
       "http://example.com/path/to:something"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-const invalidProtocolRegex = /^(%20|\s)*(javascript|data)/im;
+const invalidProtocolRegex = /^(%20|\s)*(javascript|data|vbscript)/im;
 const ctrlCharactersRegex = /[^\x20-\x7EÀ-ž]/gim;
 const urlSchemeRegex = /^([^:]+):/gm;
 const relativeFirstCharacters = [".", "/"];


### PR DESCRIPTION
Introducing `vbscript` protocol sanitization.

Although VBScript has been discontinued by Microsoft, it was still
shipping with IE11 until a couple of years ago. Because the disabling
of VBscript in users OSes depends on an OS update, there could still be
many clients out there using browsers capable of executing VBScript
code. On the other hand, the cost of implementing the sanitization of the
protocol in the scope of this library is low.

Fixes: https://github.com/braintree/sanitize-url/issues/26
