### PR TITLE
feat: decode html entities before sanitizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# unreleased
+
+**Breaking Changes**
+
+- Decode HTML characters automatically that would result in an XSS vulnerability when rendering links via a server rendered HTML file
+
+```js
+// decodes to javacript:alert('XSS')
+const vulnerableUrl =
+  "&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058&#0000097&#0000108&#0000101&#0000114&#0000116&#0000040&#0000039&#0000088&#0000083&#0000083&#0000039&#0000041";
+
+sanitizeUrl(vulnerableUrl); // 'about:blank'
+
+const okUrl = "https://example.com/" + vulnerableUrl;
+
+// since the javascript bit is in the path instead of the protocol
+// this is successfully sanitized
+sanitizeUrl(okUrl); // 'https://example.com/javascript:alert('XSS');
+```
+
 # 5.0.2
 
 - Fix issue where certain invisible white space characters were not being sanitized (#35)

--- a/README.md
+++ b/README.md
@@ -15,8 +15,15 @@ sanitizeUrl("https://example.com"); // 'https://example.com'
 sanitizeUrl("http://example.com"); // 'http://example.com'
 sanitizeUrl("www.example.com"); // 'www.example.com'
 sanitizeUrl("mailto:hello@example.com"); // 'mailto:hello@example.com'
+sanitizeUrl(
+  "&#104;&#116;&#116;&#112;&#115;&#0000058//&#101;&#120;&#97;&#109;&#112;&#108;&#101;&#46;&#99;&#111;&#109;"
+); // https://example.com
 
 sanitizeUrl("javascript:alert(document.domain)"); // 'about:blank'
 sanitizeUrl("jAvasCrIPT:alert(document.domain)"); // 'about:blank'
 sanitizeUrl(decodeURIComponent("JaVaScRiP%0at:alert(document.domain)")); // 'about:blank'
+// HTML encoded javascript:alert('XSS')
+sanitizeUrl(
+  "&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058&#0000097&#0000108&#0000101&#0000114&#0000116&#0000040&#0000039&#0000088&#0000083&#0000083&#0000039&#0000041"
+); // 'about:blank'
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 const invalidProtocolRegex = /^([^\w]*)(javascript|data|vbscript)/im;
+const htmlEntitiesRegex = /&#(\w+)(^\w|;)?/g;
 const ctrlCharactersRegex =
   /[\u0000-\u001F\u007F-\u009F\u2000-\u200D\uFEFF]/gim;
 const urlSchemeRegex = /^([^:]+):/gm;
@@ -8,12 +9,21 @@ function isRelativeUrlWithoutProtocol(url: string): boolean {
   return relativeFirstCharacters.indexOf(url[0]) > -1;
 }
 
+// adapted from https://stackoverflow.com/a/29824550/2601552
+function decodeHtmlCharacters(str: string) {
+  return str.replace(htmlEntitiesRegex, (match, dec) => {
+    return String.fromCharCode(dec);
+  });
+}
+
 export function sanitizeUrl(url?: string): string {
-  if (!url) {
+  const sanitizedUrl = decodeHtmlCharacters(url || "")
+    .replace(ctrlCharactersRegex, "")
+    .trim();
+
+  if (!sanitizedUrl) {
     return "about:blank";
   }
-
-  const sanitizedUrl = url.replace(ctrlCharactersRegex, "").trim();
 
   if (isRelativeUrlWithoutProtocol(sanitizedUrl)) {
     return sanitizedUrl;


### PR DESCRIPTION
[Jira](https://engineering.paypalcorp.com/jira/browse/DTBTSDK-1485)

Addresses a reported XSS vulnerability in this package. 

If the urls provided are HTML encoded, they'll remain HTML encoded when dynamically created using the DOM api. However, if rendered as HTML from the server, they'll get converted to readable entities without sanitization.

This update decodes the HTML in the url before sanitizing.

It's technically a breaking change, since it's transforming the URL, so it'll go out as v6.