### PR TITLE
feat: add option to pass default url in case of invalid protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unreleased
+
+- Pass default url to be returned (if present) instead of "about:blank"
+
 ## 6.0.0
 
 **Breaking Changes**

--- a/README.md
+++ b/README.md
@@ -26,4 +26,7 @@ sanitizeUrl(decodeURIComponent("JaVaScRiP%0at:alert(document.domain)")); // 'abo
 sanitizeUrl(
   "&#0000106&#0000097&#0000118&#0000097&#0000115&#0000099&#0000114&#0000105&#0000112&#0000116&#0000058&#0000097&#0000108&#0000101&#0000114&#0000116&#0000040&#0000039&#0000088&#0000083&#0000083&#0000039&#0000041"
 ); // 'about:blank'
+
+// Default URL in case of invalid protocols
+sanitizeUrl("javascript:alert(document.domain)", "default-url"); // 'default-url'
 ```

--- a/src/__tests__/test.ts
+++ b/src/__tests__/test.ts
@@ -194,6 +194,11 @@ describe("sanitizeUrl", () => {
           `http://example.com#${protocol}:foo`
         );
       });
+
+      it(`replaces ${protocol} urls with passed default url`, () => {
+        const defaultURL = 'http://example.com/path/to:something-else'
+        expect(sanitizeUrl(`${protocol}:alert(document.domain)`, defaultURL)).toBe(defaultURL);
+      });
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,13 +16,13 @@ function decodeHtmlCharacters(str: string) {
   });
 }
 
-export function sanitizeUrl(url?: string): string {
+export function sanitizeUrl(url?: string, defaultURL: string = "about:blank"): string {
   const sanitizedUrl = decodeHtmlCharacters(url || "")
     .replace(ctrlCharactersRegex, "")
     .trim();
 
   if (!sanitizedUrl) {
-    return "about:blank";
+    return defaultURL;
   }
 
   if (isRelativeUrlWithoutProtocol(sanitizedUrl)) {
@@ -38,7 +38,7 @@ export function sanitizeUrl(url?: string): string {
   const urlScheme = urlSchemeParseResults[0];
 
   if (invalidProtocolRegex.test(urlScheme)) {
-    return "about:blank";
+    return defaultURL;
   }
 
   return sanitizedUrl;


### PR DESCRIPTION
Pass an optional parameter in `sanitizeUrl` to pass a default url which can be returned instead of "about;blank" in case the url being sanitized has invalid protocols.

This gives an option to redirect user to a default url, say homepage of the site instead of a blank page which would significantly affect UX.