### PR TITLE
Sanitize Null Byte Prior to HTML Decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+UNRELEASED
+
+- Add additional null byte sanitization prior to html decoding (#48)
+
 ## 6.0.3
 
 - Add null check to beginning of `sanitizeUrl` function ([#54](https://github.com/braintree/sanitize-url/issues/54))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-UNRELEASED
+## UNRELEASED
 
 - Add additional null byte sanitization prior to html decoding (#48)
 

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -107,6 +107,7 @@ describe("sanitizeUrl", () => {
       "jav&#x09;ascript:alert('XSS');",
       " &#14; javascript:alert('XSS');",
       "javasc&Tab;ript: alert('XSS');",
+      "javasc&#\u0000x09;ript:alert(1)",
     ];
 
     attackVectors.forEach((vector) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ function isRelativeUrlWithoutProtocol(url: string): boolean {
 
 // adapted from https://stackoverflow.com/a/29824550/2601552
 function decodeHtmlCharacters(str: string) {
-  const removedNullByte = str.replace(ctrlCharactersRegex, "")
+  const removedNullByte = str.replace(ctrlCharactersRegex, "");
   return removedNullByte.replace(htmlEntitiesRegex, (match, dec) => {
     return String.fromCharCode(dec);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,8 @@ function isRelativeUrlWithoutProtocol(url: string): boolean {
 
 // adapted from https://stackoverflow.com/a/29824550/2601552
 function decodeHtmlCharacters(str: string) {
-  return str.replace(htmlEntitiesRegex, (match, dec) => {
+  const removedNullByte = str.replace(ctrlCharactersRegex, "")
+  return removedNullByte.replace(htmlEntitiesRegex, (match, dec) => {
     return String.fromCharCode(dec);
   });
 }


### PR DESCRIPTION
Adds an additional null byte check prior to HTML decoding.

Fixes issue reported in #48 

For internal tracking purposes: Jira -> LI-16155