### PR TITLE
fix: don't allow script tags in url path

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -127,6 +127,12 @@ describe("sanitizeUrl", () => {
     ).toBe("https://example.com/javascript:alert('XSS')");
   });
 
+  it("removes script tags from urls", () => {
+    expect(
+      sanitizeUrl("https://example.com/path/to<script>alert('XSS')</script>")
+    ).toBe("https://example.com/path/toalert('XSS')");
+  });
+
   describe("invalid protocols", () => {
     describe.each(["javascript", "data", "vbscript"])("%s", (protocol) => {
       it(`replaces ${protocol} urls with ${BLANK_URL}`, () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,5 +57,9 @@ export function sanitizeUrl(url?: string): string {
     return BLANK_URL;
   }
 
+  const scriptTagPattern = /<(\/|\s)*script.*?>/gim;
+  if (scriptTagPattern.test(sanitizedUrl)) {
+    return sanitizedUrl.replace(scriptTagPattern, "");
+  }
   return sanitizedUrl;
 }


### PR DESCRIPTION
Currently, it doesn't sanitize the URL by removing script tags which can lead to XSS as well (eg in cases where content loaded from an external URL in iframe)  hence I have created this PR to fix the same

Prev
```
sanitizeUrl("https://example.com/path/to<script>alert('XSS')</script>") => https://example.com/path/to<script>alert('XSS')</script>
```

Now
```
sanitizeUrl("https://example.com/path/to<script>alert('XSS')</script>") => https://example.com/path/toalert('XSS')</script>
```