### PR TITLE
LI-38822 Handle Whitespace Escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## UNRELEASED
+
+- Improve sanitization of whitespace escapes
+
 ## 7.0.1
 
 - Improve sanitization of HTML entities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 7.0.1
+
 - Improve sanitization of HTML entities
 
 ## 7.0.0

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -138,6 +138,7 @@ describe("sanitizeUrl", () => {
       "javascrip%255Ctt:alert()",
       "javascrip%25%35Ctt:alert()",
       "javascrip%25%35%43tt:alert()",
+      "javascrip%25%32%35%25%33%35%25%34%33tt:alert()",
     ];
 
     attackVectors.forEach((vector) => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -138,7 +138,8 @@ describe("sanitizeUrl", () => {
       "javascrip%255Ctt:alert()",
       "javascrip%25%35Ctt:alert()",
       "javascrip%25%35%43tt:alert()",
-      "javascrip%25%32%35%25%33%35%25%34%33tt:alert()",
+      "javascrip%25%32%35%25%33%35%25%34%33rt:alert()",
+      "javascrip%255Crt:alert('%25xss')",
     ];
 
     attackVectors.forEach((vector) => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -132,7 +132,12 @@ describe("sanitizeUrl", () => {
       "javascri\npt:alert('xss')",
       "javascri\rpt:alert('xss')",
       "javascri\tpt:alert('xss')",
-      "javascrip\x74t:alert('XSS')",
+      "javascrip\\%74t:alert('XSS')",
+      "javascrip%5c%72t:alert()",
+      "javascrip%5Ctt:alert()",
+      "javascrip%255Ctt:alert()",
+      "javascrip%25%35Ctt:alert()",
+      "javascrip%25%35%43tt:alert()",
     ];
 
     attackVectors.forEach((vector) => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -127,6 +127,19 @@ describe("sanitizeUrl", () => {
     ).toBe("https://example.com/javascript:alert('XSS')");
   });
 
+  it("removes whitespace escape sequences", () => {
+    const attackVectors = [
+      "javascri\npt:alert('xss')",
+      "javascri\rpt:alert('xss')",
+      "javascri\tpt:alert('xss')",
+      "javascrip\x74t:alert('XSS')",
+    ];
+
+    attackVectors.forEach((vector) => {
+      expect(sanitizeUrl(vector)).toBe(BLANK_URL);
+    });
+  });
+
   describe("invalid protocols", () => {
     describe.each(["javascript", "data", "vbscript"])("%s", (protocol) => {
       it(`replaces ${protocol} urls with ${BLANK_URL}`, () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,5 +4,6 @@ export const htmlCtrlEntityRegex = /&(newline|tab);/gi;
 export const ctrlCharactersRegex =
   /[\u0000-\u001F\u007F-\u009F\u2000-\u200D\uFEFF]/gim;
 export const urlSchemeRegex = /^.+(:|&colon;)/gim;
+export const whitespaceEscapeChars = /\\[nrt]/g;
 export const relativeFirstCharacters = [".", "/"];
 export const BLANK_URL = "about:blank";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const htmlCtrlEntityRegex = /&(newline|tab);/gi;
 export const ctrlCharactersRegex =
   /[\u0000-\u001F\u007F-\u009F\u2000-\u200D\uFEFF]/gim;
 export const urlSchemeRegex = /^.+(:|&colon;)/gim;
-export const whitespaceEscapeChars = /\\[nrt]/g;
+export const whitespaceEscapeCharsRegex =
+  /(\\|%5[cC])((%(6[eE]|72|74))|[nrt])/g;
 export const relativeFirstCharacters = [".", "/"];
 export const BLANK_URL = "about:blank";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   invalidProtocolRegex,
   relativeFirstCharacters,
   urlSchemeRegex,
+  whitespaceEscapeChars,
 } from "./constants";
 
 function isRelativeUrlWithoutProtocol(url: string): boolean {
@@ -30,11 +31,13 @@ export function sanitizeUrl(url?: string): string {
     decodedUrl = decodeHtmlCharacters(decodedUrl)
       .replace(htmlCtrlEntityRegex, "")
       .replace(ctrlCharactersRegex, "")
+      .replace(whitespaceEscapeChars, "")
       .trim();
     charsToDecode =
       decodedUrl.match(ctrlCharactersRegex) ||
       decodedUrl.match(htmlEntitiesRegex) ||
-      decodedUrl.match(htmlCtrlEntityRegex);
+      decodedUrl.match(htmlCtrlEntityRegex) ||
+      decodedUrl.match(whitespaceEscapeChars);
   } while (charsToDecode && charsToDecode.length > 0);
   const sanitizedUrl = decodedUrl;
   if (!sanitizedUrl) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 import {
   BLANK_URL,
   ctrlCharactersRegex,
+  hexCodesRegex,
   htmlCtrlEntityRegex,
   htmlEntitiesRegex,
   invalidProtocolRegex,
   relativeFirstCharacters,
   urlSchemeRegex,
-  whitespaceEscapeChars,
+  whitespaceEscapeCharsRegex,
 } from "./constants";
 
 function isRelativeUrlWithoutProtocol(url: string): boolean {
@@ -26,18 +27,19 @@ export function sanitizeUrl(url?: string): string {
     return BLANK_URL;
   }
   let charsToDecode;
-  let decodedUrl = url;
+  let decodedUrl = decodeURIComponent(url);
+
   do {
     decodedUrl = decodeHtmlCharacters(decodedUrl)
       .replace(htmlCtrlEntityRegex, "")
       .replace(ctrlCharactersRegex, "")
-      .replace(whitespaceEscapeChars, "")
+      .replace(whitespaceEscapeCharsRegex, "")
       .trim();
     charsToDecode =
       decodedUrl.match(ctrlCharactersRegex) ||
       decodedUrl.match(htmlEntitiesRegex) ||
       decodedUrl.match(htmlCtrlEntityRegex) ||
-      decodedUrl.match(whitespaceEscapeChars);
+      decodedUrl.match(whitespaceEscapeCharsRegex);
   } while (charsToDecode && charsToDecode.length > 0);
   const sanitizedUrl = decodedUrl;
   if (!sanitizedUrl) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ export function sanitizeUrl(url?: string): string {
       .replace(ctrlCharactersRegex, "")
       .replace(whitespaceEscapeCharsRegex, "")
       .trim();
+    decodedUrl = decodeURIComponent(decodedUrl);
     charsToDecode =
       decodedUrl.match(ctrlCharactersRegex) ||
       decodedUrl.match(htmlEntitiesRegex) ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,12 +21,23 @@ function decodeHtmlCharacters(str: string) {
   });
 }
 
+function decodeURI(uri: string): string {
+  try {
+    return decodeURIComponent(uri);
+  } catch (e: unknown) {
+    // Ignoring error
+    // It is possible that the URI contains a `%` not associated
+    // with URI/URL-encoding.
+    return uri;
+  }
+}
+
 export function sanitizeUrl(url?: string): string {
   if (!url) {
     return BLANK_URL;
   }
   let charsToDecode;
-  let decodedUrl = decodeURIComponent(url);
+  let decodedUrl = decodeURI(url);
 
   do {
     decodedUrl = decodeHtmlCharacters(decodedUrl)
@@ -34,7 +45,9 @@ export function sanitizeUrl(url?: string): string {
       .replace(ctrlCharactersRegex, "")
       .replace(whitespaceEscapeCharsRegex, "")
       .trim();
-    decodedUrl = decodeURIComponent(decodedUrl);
+
+    decodedUrl = decodeURI(decodedUrl);
+
     charsToDecode =
       decodedUrl.match(ctrlCharactersRegex) ||
       decodedUrl.match(htmlEntitiesRegex) ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import {
   BLANK_URL,
   ctrlCharactersRegex,
-  hexCodesRegex,
   htmlCtrlEntityRegex,
   htmlEntitiesRegex,
   invalidProtocolRegex,


### PR DESCRIPTION
Add logic for sanitize-url to handle white space escapes and encoded whitespace, such as:
* `\n`
* `\r`
* `\t`

Example: 
  * input: `javascrip\nt:alert('whitespace')`
  * output: `about:blank`