### PR TITLE
docs: Update incorrect sanitizeUrl documentation examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ npm install -S @braintree/sanitize-url
 ```js
 var sanitizeUrl = require("@braintree/sanitize-url").sanitizeUrl;
 
-sanitizeUrl("https://example.com"); // 'https://example.com'
-sanitizeUrl("http://example.com"); // 'http://example.com'
+sanitizeUrl("https://example.com"); // 'https://example.com/'
+sanitizeUrl("http://example.com"); // 'http://example.com/'
 sanitizeUrl("www.example.com"); // 'www.example.com'
 sanitizeUrl("mailto:hello@example.com"); // 'mailto:hello@example.com'
 sanitizeUrl(
   "&#104;&#116;&#116;&#112;&#115;&#0000058//&#101;&#120;&#97;&#109;&#112;&#108;&#101;&#46;&#99;&#111;&#109;"
-); // https://example.com
+); // https://example.com/
 
 sanitizeUrl("javascript:alert(document.domain)"); // 'about:blank'
 sanitizeUrl("jAvasCrIPT:alert(document.domain)"); // 'about:blank'


### PR DESCRIPTION
Update README examples to match the current behavior in the latest version.

The examples in the documentation show slightly different output format compared to the actual behavior in the latest version. While this doesn't affect functionality, updating the documentation helps avoid confusion for new users.

![1739197410373](https://github.com/user-attachments/assets/e7c75c1d-b23e-43b1-931a-874967d5f8f5)


