### PR TITLE
fix: fallback for URL.canParse missing in some environments (#92)

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -3,6 +3,32 @@ import { sanitizeUrl } from "..";
 import { BLANK_URL } from "../constants";
 
 describe("sanitizeUrl", () => {
+  describe("URL.canParse fallback", () => {
+    const originalCanParse = URL.canParse;
+
+    afterEach(() => {
+      // Restore URL.canParse after each test
+      URL.canParse = originalCanParse;
+    });
+
+    it("works when URL.canParse is not available", () => {
+      // @ts-expect-error - intentionally removing URL.canParse to test fallback
+      delete URL.canParse;
+
+      expect(sanitizeUrl("https://example.com")).toBe("https://example.com/");
+      expect(sanitizeUrl("http://example.com/path")).toBe(
+        "http://example.com/path",
+      );
+    });
+
+    it("returns BLANK_URL for invalid URLs when URL.canParse is not available", () => {
+      // @ts-expect-error - intentionally removing URL.canParse to test fallback
+      delete URL.canParse;
+
+      expect(sanitizeUrl("https://")).toBe(BLANK_URL);
+    });
+  });
+
   it("does not alter http URLs with alphanumeric characters", () => {
     expect(sanitizeUrl("http://example.com/path/to:something")).toBe(
       "http://example.com/path/to:something",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,17 @@ function decodeHtmlCharacters(str: string) {
 }
 
 function isValidUrl(url: string): boolean {
-  return URL.canParse(url);
+  if (typeof URL.canParse === "function") {
+    return URL.canParse(url);
+  }
+
+  // Fallback for environments without URL.canParse support
+  try {
+    const parsedUrl = new URL(url);
+    return Boolean(parsedUrl);
+  } catch {
+    return false;
+  }
 }
 
 function decodeURI(uri: string): string {


### PR DESCRIPTION
# Summary of changes
This PR adds a safe fallback when URL.canParse is not available in the runtime environment.
Some environments (older Node.js / browsers) do not implement URL.canParse, which caused sanitizeUrl to throw a TypeError.
-

## Checklist

- [x] Added a changelog entry
- [x] Relevant test coverage
- [x] Tested and confirmed flows affected by this change are functioning as expected

## Authors
@Shaharyar07

> List GitHub usernames for everyone who contributed to this pull request.

### Reviewers

@braintree/team-sdk-js
