### PR TITLE
fix: restrict GITHUB_TOKEN permissions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - "*"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Unit Tests on Ubuntu"


### PR DESCRIPTION
## Summary of changes

- Add explicit `permissions: contents: read` block to `.github/workflows/ci.yml`
- Limits `GITHUB_TOKEN` to the minimum scope required for `actions/checkout`

## Checklist

- [ ] Added a changelog entry
- [ ] Relevant test coverage
- [x] Tested and confirmed flows affected by this change are functioning as expected

## Authors

@lvandenboom

## Reviewers

@braintree/team-sdk-js